### PR TITLE
Utilizamos frames en lugar de page ID

### DIFF
--- a/memory-management/simulation/defs.h
+++ b/memory-management/simulation/defs.h
@@ -16,16 +16,17 @@
 // Estructura que representa una página de memoria con su ID, el ID del marco en el que se encuentra (si está en
 // memoria) y un indicador de validez.
 typedef struct {
-    int page_id;  // Identificador único de la página.
+    int page_id;  // Identificador único (en el proceso) de la página.
     int frame_id; // ID del marco que contiene la página; -1 si la página no está en memoria.
     int valid;    // Indica si la página está cargada en memoria (1) o no (0).
 } Page;
 
 // Estructura que representa un marco de memoria física.
 typedef struct {
-    int frame_id; // Identificador único del marco de memoria.
-    int page_id;  // ID de la página actualmente ocupando este marco; -1 si el marco está libre.
-    int occupied; // Estado de ocupación del marco: 1 si está ocupado, 0 si está libre.
+    int frame_id;   // Identificador único del marco de memoria.
+    int process_id; // ID del proceso que es dueño del marco.
+    int page_id;    // ID de la página actualmente ocupando este marco; -1 si el marco está libre.
+    int occupied;   // Estado de ocupación del marco: 1 si está ocupado, 0 si está libre.
 } Frame;
 
 // Tabla de páginas que asocia páginas de memoria virtual a marcos de memoria física.

--- a/memory-management/simulation/memory.c
+++ b/memory-management/simulation/memory.c
@@ -87,7 +87,7 @@ void printMemoryState(Frame frames[], int num_frames, ProcessPageTables ppt, Que
 
     fprintf(file, "\nContenido de la cola FIFO (orden de desalojo):\n");
     for (Node* current = queue.front; current != NULL; current = current->next) {
-        fprintf(file, "Página %d -> ", current->page_id);
+        fprintf(file, "Marco %d -> ", current->frame_id);
     }
     fprintf(file, "NULL\n");
 

--- a/memory-management/simulation/queue.c
+++ b/memory-management/simulation/queue.c
@@ -1,6 +1,7 @@
 // queue.c
 #include "queue.h"
 #include <assert.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 void freeQueue(Queue* queue) {
@@ -11,4 +12,13 @@ void freeQueue(Queue* queue) {
         free(current);
         current = next;
     }
+}
+
+bool isInQueue(const Queue* queue, int frame_id) {
+    for (Node* n = queue->front; n != NULL; n = n->next) {
+        if (n->frame_id == frame_id) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/memory-management/simulation/queue.h
+++ b/memory-management/simulation/queue.h
@@ -2,11 +2,9 @@
 #ifndef QUEUE_H
 #define QUEUE_H
 
-#include "defs.h"
-
 // Nodo para construir una cola utilizada en la gestión de páginas.
 typedef struct Node {
-    int page_id;       // ID de la página en el nodo.
+    int frame_id;      // ID del frame en el nodo.
     struct Node* next; // Puntero al siguiente nodo en la cola.
     struct Node* prev; // Puntero al nodo anterior en la cola.
 } Node;
@@ -17,9 +15,9 @@ typedef struct Queue {
     Node* rear;  // Puntero al último nodo de la cola.
 
     void (*free)(struct Queue* queue);
-    void (*adjust)(struct Queue* queue, int page_id);
-    void (*enqueue)(struct Queue* queue, int page_id);
-    int (*dequeue)(struct Queue* queue, PageTable* pt);
+    void (*adjust)(struct Queue* queue, int frame_id);
+    void (*enqueue)(struct Queue* queue, int frame_id);
+    int (*dequeue)(struct Queue* queue);
 } Queue;
 
 typedef enum {

--- a/memory-management/simulation/request.c
+++ b/memory-management/simulation/request.c
@@ -5,21 +5,21 @@
 #include "queue.h"
 #include <stddef.h>
 
-int evictPage(PageTable* pt, Frame frames[], Queue* queue) {
-    int evictedPageId = queue->dequeue(queue, pt);
-    if (evictedPageId == -1) {
+int evictFrame(PageTable* pt, Frame frames[], Queue* queue) {
+    int evictedFrameId = queue->dequeue(queue);
+    if (evictedFrameId == -1) {
         logEvent("No hay páginas válidas en la cola FIFO para desalojar.");
         return -1;
     }
 
-    int frameIndex                    = pt->pages[evictedPageId].frame_id;
-    pt->pages[evictedPageId].valid    = 0;
-    pt->pages[evictedPageId].frame_id = -1;
-    frames[frameIndex].page_id        = -1;
-    frames[frameIndex].occupied       = 0;
+    int pageId                      = frames[evictedFrameId].page_id;
+    pt->pages[pageId].valid         = 0;
+    pt->pages[pageId].frame_id      = -1;
+    frames[evictedFrameId].page_id  = -1;
+    frames[evictedFrameId].occupied = 0;
 
-    logEvent("Fallos de página: la página %d desalojada del marco %d", evictedPageId, frameIndex);
-    return frameIndex;
+    logEvent("Fallos de página: la página %d desalojada del marco %d", evictedFrameId, pageId);
+    return evictedFrameId;
 }
 
 void processPageRequest(PageTable* pt, Frame frames[], Queue* queue, PageRequest request) {
@@ -30,28 +30,29 @@ void processPageRequest(PageTable* pt, Frame frames[], Queue* queue, PageRequest
     logEvent("Estado inicial: Página %d es %s", request.page_id,
              pt->pages[request.page_id].valid ? "válida" : "no válida");
 
-    if (pt->pages[request.page_id].valid) {
+    Page* page = &pt->pages[request.page_id];
+    if (page->valid) {
         logEvent("Página %d ya está en memoria.", request.page_id);
         if (queue->adjust != NULL) {
-            queue->adjust(queue, request.page_id);
+            queue->adjust(queue, page->frame_id);
         }
         return;
     }
 
     int frameIndex = findFreeFrame(frames, NUM_FRAMES);
     if (frameIndex == -1) {
-        frameIndex = evictPage(pt, frames, queue);
+        frameIndex = evictFrame(pt, frames, queue);
         if (frameIndex == -1) {
             return;
         }
     }
 
-    frames[frameIndex].page_id          = request.page_id;
-    frames[frameIndex].occupied         = 1;
-    pt->pages[request.page_id].frame_id = frameIndex;
-    pt->pages[request.page_id].valid    = 1;
+    frames[frameIndex].page_id  = request.page_id;
+    frames[frameIndex].occupied = 1;
+    page->frame_id              = frameIndex;
+    page->valid                 = 1;
 
-    queue->enqueue(queue, request.page_id);
+    queue->enqueue(queue, frameIndex);
 
     logEvent("Página %d cargada en el marco %d", request.page_id, frameIndex);
 


### PR DESCRIPTION
El motivo para utilizar frames en lugar de page ID es que múltiples procesos pueden tener el mismo page ID, pero estos apuntan a posiciones de memoria diferentes (la base de manejo de memoria dinámica). Esto quiere decir que:
- En el modelo FIFO, el mismo page ID se puede insertar múltiples veces, pero si al eliminarlo los procesos no coinciden, estariamos quitando una página incorrecta de memoria.
- De forma similar en el modelo LRU, podríamos marcar como accedido a una página que en realidad no es físicamente la correcta si los procesos no coinciden.